### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/src/BitReader/keywords.txt
+++ b/src/BitReader/keywords.txt
@@ -7,4 +7,4 @@ setBuffer	KEYWORD2
 read	KEYWORD2
 write	KEYWORD2
 skip	KEYWORD2
-getAddress  KEYWORD2
+getAddress	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords